### PR TITLE
Keyboard undo redo

### DIFF
--- a/typescriptSrc/editor.ts
+++ b/typescriptSrc/editor.ts
@@ -638,7 +638,7 @@ module editor {
         }
     }
 
-        //This version of undo is meant to be called by the keyboard shortcut.
+    //This version of undo is meant to be called by the keyboard shortcut.
     //It skips open nodes, which would otherwise reopen themselves and disable keyboard shortcuts until closed.
     function keyboardUndo() : void {
         let finished : boolean = false;
@@ -648,11 +648,8 @@ module editor {
             sel = undostack.pop() as Selection ;
             finished = hasOpenNodes(sel)
         }
-        if(finished)
-        {
-            currentSelection = sel;
-            generateHTMLSoon();
-        }
+        currentSelection = sel;
+        generateHTMLSoon();
         return;
     }
 
@@ -665,11 +662,8 @@ module editor {
             sel = redostack.pop() as Selection;
             finished = hasOpenNodes(sel)
         }
-        if(finished)
-        {
-            currentSelection = sel;
-            generateHTMLSoon();
-        }
+        currentSelection = sel;
+        generateHTMLSoon();
         return;
     }
 

--- a/typescriptSrc/editor.ts
+++ b/typescriptSrc/editor.ts
@@ -426,6 +426,20 @@ module editor {
                 e.stopPropagation(); 
                 e.preventDefault(); 
             }
+            // Undo: Cntl-Z or Cmd-Z
+            else if ((e.ctrlKey || e.metaKey) && !e.shiftKey &&  e.which === 90) 
+            {
+                undo();
+                e.stopPropagation(); 
+                e.preventDefault(); 
+            }
+            // Redo: Cntl-Y or Cmd-Y (or Ctrl-Shift-Z or Cmd-Shift-Z)
+            else if ((e.ctrlKey || e.metaKey) && (e.which === 89 || (e.shiftKey && e.which == 90))) 
+            {
+                redo();
+                e.stopPropagation(); 
+                e.preventDefault(); 
+            }
             else if (e.which === 38) // up arrow
             {
                 treeMgr.moveUp( currentSelection ).map( (sel : Selection) =>

--- a/typescriptSrc/editor.ts
+++ b/typescriptSrc/editor.ts
@@ -429,14 +429,14 @@ module editor {
             // Undo: Cntl-Z or Cmd-Z
             else if ((e.ctrlKey || e.metaKey) && !e.shiftKey &&  e.which === 90) 
             {
-                undo();
+                keyboardUndo();
                 e.stopPropagation(); 
                 e.preventDefault(); 
             }
             // Redo: Cntl-Y or Cmd-Y (or Ctrl-Shift-Z or Cmd-Shift-Z)
             else if ((e.ctrlKey || e.metaKey) && (e.which === 89 || (e.shiftKey && e.which == 90))) 
             {
-                redo();
+                keyboardRedo();
                 e.stopPropagation(); 
                 e.preventDefault(); 
             }
@@ -622,12 +622,75 @@ module editor {
         else return false;
     }
 
+    //This version of undo is meant to be called by the keyboard shortcut.
+    //It skips open nodes, which would otherwise reopen themselves and disable keyboard shortcuts until closed.
+    function keyboardUndo() : void {
+        let finished : boolean = false;
+        let sel : Selection = currentSelection;
+        while (undostack.length !== 0 && !finished)  {
+            finished = true;
+            redostack.push(sel);
+            sel = undostack.pop() as Selection ;
+            if(Math.abs(sel.anchor() - sel.focus()) == 1)
+            {
+                if(sel.selectedNodes()[0].label().isOpen())
+                { //Keep going if the selected node is open.
+                    finished = false;
+                }
+                for(let child of sel.selectedNodes()[0].children())
+                { //deal with cases where a child of the selected node is open, but not the selected node itself.
+                    if(child.label().isOpen())
+                    {
+                        finished = false;
+                    }
+                }
+            }
+        }
+        if(finished)
+        {
+            currentSelection = sel;
+            generateHTMLSoon();
+        }
+        return;
+    }
+
     function undo() : void {
         if (undostack.length !== 0)  {
             redostack.push(currentSelection);
             currentSelection = undostack.pop() as Selection ;
             generateHTMLSoon();
         }
+    }
+
+    //This version of redo is meant to be called by the keyboard shortcut.
+    function keyboardRedo() : void {
+        let finished : boolean = false;
+        let sel : Selection = currentSelection;
+        while (redostack.length !== 0 && !finished)  {
+            finished = true;
+            undostack.push(sel);
+            sel = redostack.pop() as Selection ;
+            if(Math.abs(sel.anchor() - sel.focus()) == 1)
+            {
+                if(sel.selectedNodes()[0].label().isOpen())
+                { //Keep going if the selected node is open.
+                    finished = false;
+                }
+                for(let child of sel.selectedNodes()[0].children())
+                { //deal with cases where a child of the selected node is open, but not the selected node itself.
+                    if(child.label().isOpen())
+                    {
+                        finished = false;
+                    }
+                }
+            }
+        }
+        if(finished)
+        {
+            currentSelection = sel;
+            generateHTMLSoon();
+        }
+        return;
     }
 
     function redo() : void {


### PR DESCRIPTION
Added undo and redo keyboard shortcuts. As a note, editing a label disables keyboard shortcuts so if you undo or redo into a point where you were doing that you can't use the keyboard to continue undoing - you need to use the UI. Not sure what to do about that. Thoughts?