### PR TITLE
Improve edits

### DIFF
--- a/typescriptSrc/editor.ts
+++ b/typescriptSrc/editor.ts
@@ -454,30 +454,57 @@ module editor {
                 e.stopPropagation(); 
                 e.preventDefault(); 
             }
-            else if (e.which === 38) // up arrow
+            else if (e.which === 38 && ! e.shiftKey ) // up arrow
             {
                 treeMgr.moveUp( currentSelection ).map( (sel : Selection) =>
                          update( sel ) ) ;
                 e.stopPropagation(); 
                 e.preventDefault(); 
             }
-            else if (e.which === 40) // down arrow
+            else if (e.which === 40 && ! e.shiftKey) // down arrow
             {
                 treeMgr.moveDown( currentSelection ).map( (sel : Selection) =>
                          update( sel ) ) ;
                 e.stopPropagation(); 
                 e.preventDefault(); 
             }
-            else if (e.which === 37) // left arrow
+            else if (e.which === 37 && ! e.shiftKey) // left arrow
             {
                 treeMgr.moveLeft( currentSelection ).map( (sel : Selection) =>
                          update( sel ) ) ;
                 e.stopPropagation(); 
                 e.preventDefault(); 
             }            
-            else if (e.which === 39) // right arrow
+            else if (e.which === 39 && ! e.shiftKey) // right arrow
             {
                 treeMgr.moveRight( currentSelection ).map( (sel : Selection) =>
+                         update( sel ) ) ;
+                e.stopPropagation(); 
+                e.preventDefault(); 
+            }else if (e.which === 38 && e.shiftKey ) // up arrow
+            {
+                treeMgr.moveFocusUp( currentSelection ).map( (sel : Selection) =>
+                         update( sel ) ) ;
+                e.stopPropagation(); 
+                e.preventDefault(); 
+            }
+            else if (e.which === 40 && e.shiftKey) // down arrow
+            {
+                treeMgr.moveFocusDown( currentSelection ).map( (sel : Selection) =>
+                         update( sel ) ) ;
+                e.stopPropagation(); 
+                e.preventDefault(); 
+            }
+            else if (e.which === 37 && e.shiftKey) // left arrow
+            {
+                treeMgr.moveFocusLeft( currentSelection ).map( (sel : Selection) =>
+                         update( sel ) ) ;
+                e.stopPropagation(); 
+                e.preventDefault(); 
+            }            
+            else if (e.which === 39 && e.shiftKey) // right arrow
+            {
+                treeMgr.moveFocusRight( currentSelection ).map( (sel : Selection) =>
                          update( sel ) ) ;
                 e.stopPropagation(); 
                 e.preventDefault(); 

--- a/typescriptSrc/pnodeEdits.ts
+++ b/typescriptSrc/pnodeEdits.ts
@@ -130,7 +130,10 @@ module pnodeEdits {
                 && 0 <= head && head < tree.count()
                 && checkSelection( tree.child(head), path.rest(), anchor, focus ) ; } }
 
-    /** Move out. I.e. to the parent if possible. */
+    /** Move out. I.e. to the parent if possible.
+     * @param selection
+     * @param normal iff the anchor preceeds the focus.
+    */
     function moveOut( selection : Selection, normal : boolean ) : Option<Selection> {
         const root = selection.root();
         const path = selection.path();
@@ -143,6 +146,7 @@ module pnodeEdits {
         }
 
     }
+
     /** Move left. */
     function moveLeft( selection : Selection ) : Option<Selection> {
         const start = selection.start() ;
@@ -233,6 +237,36 @@ module pnodeEdits {
     /** Move Tab back. */
     function moveTabBack( selection : Selection ) : Option<Selection> {
         return moveLeft(selection) ; //In our case this is the same.
+    }
+
+    /** Move the focus one place to the right if possible.
+     * Otherwise, move up the tree.*/
+    function moveFocusRight( selection : Selection ) : Option<Selection> {
+        const anchor = selection.anchor() ;
+        const focus = selection.focus() ;
+        const root = selection.root();
+        const path = selection.path();
+        const parent = selection.parent() ;
+        console.log( "moveFocusRight: anchor is " +anchor+
+                     " focus is " +focus+ 
+                     " parent.count() is " +parent.count() ) ;
+        if( focus < parent.count() ) {
+            return some( new Selection(root, path, anchor, focus+1) ) ; }
+        else {
+            return moveOut( selection, true ) ; }
+    }
+
+    /** Move the focus one place to the left if possible.
+     * Otherwise, move up the tree.*/
+    function moveFocusLeft( selection : Selection ) : Option<Selection> {
+        const anchor = selection.anchor() ;
+        const focus = selection.focus() ;
+        const root = selection.root();
+        const path = selection.path();
+        if( focus > 0 ) {
+            return some( new Selection(root, path, anchor, focus-1) ) ; }
+        else {
+            return moveOut( selection, false ) ; }
     }
 
     /** Replace all selected nodes with another set of nodes. */
@@ -654,8 +688,8 @@ module pnodeEdits {
         const sel = opt.first() ;
         const start = sel.start() ;
         const end = sel.end() ;
-        if( end - start === 1 ) {
-            // Any single node selection is suitable
+        if( end - start >= 1 ) {
+            // Any selection containing 1 or more nodes is
             return true ; }
         else if( end === start ) {
             // Dropzones are suitable
@@ -687,6 +721,17 @@ module pnodeEdits {
         {
             return false ;
         }
+    }
+
+    /** Is this a suitable selection to stop at for the shift-up arrow and shift-down arrow keys are used to move the focus.
+    */
+    function upDownFocusMoveSuitable( opt : Option<Selection> ) : boolean {
+        // Need to stop when we can go no further to the up or down.
+        if( opt.isEmpty() ) return true ;
+        // Otherwise stop only on selections whose
+        // parents have vertical layout.
+        const sel = opt.first() ;
+        return sel.parent().hasVerticalLayout() ;
     }
 
     /** Is this a suitable selection to stop at for tab keys.
@@ -794,6 +839,78 @@ module pnodeEdits {
     }
 
     export const downEdit = new DownEdit() ;
+
+    /** 
+     * Move Focus Left edit
+     */
+    class MoveFocusLeftEdit extends AbstractEdit<Selection> {
+
+        constructor() { super() ; }
+        
+        public applyEdit( selection : Selection ) : Option<Selection> {
+            let opt = moveFocusLeft( selection ) ;
+            while( ! leftRightSuitable(opt) ) {
+                const sel = opt.first() ;
+                opt = moveFocusLeft( sel ) }
+            return opt ;
+        }
+    }
+
+    export const moveFocusLeftEdit = new MoveFocusLeftEdit() ;
+
+    /** 
+     * Move Focus Right edit
+     */
+    class MoveFocusRightEdit extends AbstractEdit<Selection> {
+
+        constructor() { super() ; }
+        
+        public applyEdit( selection : Selection ) : Option<Selection> {
+            let opt = moveFocusRight( selection ) ;
+            while( ! leftRightSuitable(opt) ) {
+                const sel = opt.first() ;
+                opt = moveFocusRight( sel ) }
+            return opt ;
+        }
+    }
+
+    export const moveFocusRightEdit = new MoveFocusRightEdit() ;
+
+    /** 
+     * Move Focus Up edit
+     */
+    class MoveFocusUpEdit extends AbstractEdit<Selection> {
+
+        constructor() { super() ; }
+        
+        public applyEdit( selection : Selection ) : Option<Selection> {
+            let opt = moveFocusLeft( selection ) ;
+            while( ! upDownFocusMoveSuitable(opt) ) {
+                const sel = opt.first() ;
+                opt = moveFocusLeft( sel ) }
+            return opt ;
+        }
+    }
+
+    export const moveFocusUpEdit = new MoveFocusUpEdit() ;
+
+    /** 
+     * Move Focus Down edit
+     */
+    class MoveFocusDownEdit extends AbstractEdit<Selection> {
+
+        constructor() { super() ; }
+        
+        public applyEdit( selection : Selection ) : Option<Selection> {
+            let opt = moveFocusRight( selection ) ;
+            while( ! upDownFocusMoveSuitable(opt) ) {
+                const sel = opt.first() ;
+                opt = moveFocusRight( sel ) }
+            return opt ;
+        }
+    }
+
+    export const moveFocusDownEdit = new MoveFocusDownEdit() ;
 
     /** 
      * Tab edit

--- a/typescriptSrc/treeManager.ts
+++ b/typescriptSrc/treeManager.ts
@@ -291,6 +291,26 @@ module treeManager {
             return edit.applyEdit(selection);
         }
 
+        public moveFocusLeft( selection:Selection ) : Option<Selection> {
+            const edit = pnodeEdits.moveFocusLeftEdit;
+            return edit.applyEdit(selection);
+        }
+
+        public moveFocusRight( selection:Selection ) : Option<Selection> {
+            const edit = pnodeEdits.moveFocusRightEdit;
+            return edit.applyEdit(selection);
+        }
+
+        public moveFocusUp( selection:Selection ) : Option<Selection> {
+            const edit = pnodeEdits.moveFocusUpEdit;
+            return edit.applyEdit(selection);
+        }
+
+        public moveFocusDown( selection:Selection ) : Option<Selection> {
+            const edit = pnodeEdits.moveFocusDownEdit;
+            return edit.applyEdit(selection);
+        }
+
         public moveTabForward( selection:Selection ) : Option<Selection> {
             const edit = pnodeEdits.tabForwardEdit;
             return edit.applyEdit(selection);


### PR DESCRIPTION
Implementing shifted-arrrow keys.  These move the focus, but try to leave the anchor where it is.