### PR TITLE
Palette items for call and null

### DIFF
--- a/typescriptSrc/createHtmlElements.ts
+++ b/typescriptSrc/createHtmlElements.ts
@@ -24,8 +24,8 @@ module createHtmlElements {
 		const leftSideArea = $("#leftSideArea");
 		create("div", "", "buttonArea", leftSideArea);
 		const buttonArea = $("#buttonArea");
-		create("div", "evalHidden", "sidebar", leftSideArea);
-		const sidebar = $("#sidebar");
+		create("div", "evalHidden", "palette", leftSideArea);
+		const palette = $("#palette");
 
 		createHidden("div", "stack evalVisible", "stackbar", leftSideArea, null);
 		create("table", null, "stackVal", $("#stackbar"));
@@ -44,12 +44,16 @@ module createHtmlElements {
 		createHidden("div", "quitworld", "quitworld", leftSideArea, "Quit World");
 		createHidden("div", "edit evalVisible", "edit", leftSideArea, "Edit");
 
-		createTexted("div", "leftSideButton buildingBlockButton palette", "if", sidebar, "?");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "while", sidebar, "\u27F3");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "var", sidebar, "x");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "stringliteral", sidebar, '""');
-		createTexted("div", "leftSideButton buildingBlockButton palette", "worldcall", sidebar, "+");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "assign", sidebar, ":=");
+		createTexted("div", "leftSideButton buildingBlockButton palette", "if", palette, "?");
+		createTexted("div", "leftSideButton buildingBlockButton palette", "while", palette, "\u27F3");
+		createTexted("div", "leftSideButton buildingBlockButton palette", "vardecl", palette, "\u03B4");
+		createTexted("div", "leftSideButton buildingBlockButton palette", "assign", palette, ":=");
+		createTexted("div", "leftSideButton buildingBlockButton palette", "var", palette, "x");
+		createTexted("div", "leftSideButton buildingBlockButton palette", "worldcall", palette, "+");
+		createTexted("div", "leftSideButton buildingBlockButton palette", "call", palette, "call");
+		createTexted("div", "leftSideButton buildingBlockButton palette", "stringliteral", palette, '""');
+		createTexted("div", "leftSideButton buildingBlockButton palette", "nullliteral", palette, "\u23da");
+		createTexted("div", "leftSideButton buildingBlockButton palette", "lambda", palette, "\u03BB");
 
 		//User-related elements. All added functionalities of the elements are in userRelated module.
 		create("div", "userBar", "userBar", upperArea);
@@ -59,9 +63,6 @@ module createHtmlElements {
 		createTexted("div", "", "userSettings", userBar, "User Settings").hide();
 		createTexted("div", "", "saveProgram", userBar, "Save Program").hide();
 		createTexted("div", "", "loadProgram", userBar, "Load Program").hide();
-
-		createTexted("div", "leftSideButton buildingBlockButton palette", "vardecl", sidebar, "\u03B4");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "lambda", sidebar, "\u03BB");
 		create("datalist", null, "oplist", contentArea);
 
 		create("div", "container evalHidden", "container", contentArea);

--- a/typescriptSrc/createHtmlElements.ts
+++ b/typescriptSrc/createHtmlElements.ts
@@ -44,16 +44,16 @@ module createHtmlElements {
 		createHidden("div", "quitworld", "quitworld", leftSideArea, "Quit World");
 		createHidden("div", "edit evalVisible", "edit", leftSideArea, "Edit");
 
-		createTexted("div", "leftSideButton buildingBlockButton palette", "if", palette, "?");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "while", palette, "\u27F3");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "vardecl", palette, "\u03B4");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "assign", palette, ":=");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "var", palette, "x");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "worldcall", palette, "+");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "call", palette, "call");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "stringliteral", palette, '""');
-		createTexted("div", "leftSideButton buildingBlockButton palette", "nullliteral", palette, "\u23da");
-		createTexted("div", "leftSideButton buildingBlockButton palette", "lambda", palette, "\u03BB");
+		createTexted("div", "leftSideButton paletteItem", "if", palette, "?");
+		createTexted("div", "leftSideButton paletteItem", "while", palette, "\u27F3");
+		createTexted("div", "leftSideButton paletteItem", "vardecl", palette, "\u03B4");
+		createTexted("div", "leftSideButton paletteItem", "assign", palette, ":=");
+		createTexted("div", "leftSideButton paletteItem", "var", palette, "x");
+		createTexted("div", "leftSideButton paletteItem", "worldcall", palette, "+");
+		createTexted("div", "leftSideButton paletteItem", "call", palette, "call");
+		createTexted("div", "leftSideButton paletteItem", "stringliteral", palette, '""');
+		createTexted("div", "leftSideButton paletteItem", "nullliteral", palette, "\u23da");
+		createTexted("div", "leftSideButton paletteItem", "lambda", palette, "\u03BB");
 
 		//User-related elements. All added functionalities of the elements are in userRelated module.
 		create("div", "userBar", "userBar", upperArea);

--- a/typescriptSrc/editor.ts
+++ b/typescriptSrc/editor.ts
@@ -52,7 +52,7 @@ module editor {
         $("#trash").click( toggleTrash ) ;
 
         makeTrashDroppable( $("#trash") ) ;
-        $( ".palette" ).draggable( {
+        $( ".paletteItem" ).draggable( {
             helper:"clone",
             revert: true,
             revertDuration: 500,
@@ -73,6 +73,12 @@ module editor {
                 /*tslint:enable:no-invalid-this*/
                 console.log( "<< Drag handler for things in pallette" ) ;
             } } ) ;
+
+        // When a palette item is clicked, insert a node at the current selection.
+        $( ".paletteItem" ).click(
+            function(this : HTMLElement, evt : Event) : void {
+                console.log( "click on " + $(this).attr("id") ) ;
+                createNodeOnCurrentSelection( $(this).attr("id") ) ; } ) ;
 
     }
 
@@ -645,6 +651,11 @@ module editor {
 
     export function getCurrentSelection() : Selection {
         return currentSelection ;
+    }
+
+    function createNodeOnCurrentSelection(id: string, nodeText?: string) : void
+    {
+        createNode( id, getCurrentSelection(), nodeText) ;
     }
 
     function createNode(id: string, selection : Selection, nodeText?: string) : void

--- a/typescriptSrc/keyboardcommands.html
+++ b/typescriptSrc/keyboardcommands.html
@@ -19,6 +19,7 @@
         <li><b>+, -, *, and /</b> will create the appropriate call expression. Also works with shift+= for + and shift+8 for *.</li>
     </ul>
     <p><b>Arrow keys and the tab key</b> to navigate your code.</p>
+    <p><b>Arrow keys while shift key is depressed</b> to expand or contract the selection.</p>
     <p><b>Space bar</b> to expand the current selection outward.</p>
     <p><b>ctrl+a</b> to select everything.</p>
     <p><b>ctrl+c</b> to add the current selection to trash.</p>

--- a/typescriptSrc/plaay-style.css
+++ b/typescriptSrc/plaay-style.css
@@ -158,7 +158,7 @@ html, body
     background-color:#262626;
 }
 
-#sidebar
+#palette
 {
     position:absolute;
     height:19em;

--- a/typescriptSrc/plaay-style.css
+++ b/typescriptSrc/plaay-style.css
@@ -186,7 +186,7 @@ html, body
     margin-top: 3px;
 }
 
-.buildingBlockButton 
+.paletteItem 
 {
     text-align: center;
     line-height: 30px;

--- a/typescriptSrc/sharedMkHtml.ts
+++ b/typescriptSrc/sharedMkHtml.ts
@@ -253,7 +253,7 @@ module sharedMkHtml
                 result.addClass( "nullLiteral" ) ;
                 result.addClass( "H" ) ;
                 result.addClass( "droppable" ) ;
-                result.text( "&#x23da;" ) ;  // The Ground symbol. I hope.
+                result.html( "&#x23da;" ) ;  // The Ground symbol. I hope.
             }
             break ;
             case labels.VariableLabel.kindConst :

--- a/typescriptSrc/sharedMkHtml.ts
+++ b/typescriptSrc/sharedMkHtml.ts
@@ -153,8 +153,6 @@ module sharedMkHtml
                 result.attr("type", "text");
                 result.attr("list", "oplist");
                 
-                // TODO Allow infix operators again some day.
-
                 let opElement : JQuery ;
                 if(! node.label().isOpen() )
                 {
@@ -179,7 +177,7 @@ module sharedMkHtml
                 if( ! node.label().isOpen() && children.length === 2 )
                 {
                     const labelString = node.label().getVal() ;
-                    if( labelString.match( /^([+/!@#$%&*_+=?;:`~&]|-|^|\\)+$/ ) !== null ) {
+                    if( stringIsInfixOperator( labelString ) ) {
                         // 2 children means the result has [ opElement dz[0] children[0] dz[1] children[1] dz[2] ]
                         assert.check( result.children().length === 6 ) ;
                         // Move the opElement to after the first child
@@ -482,6 +480,10 @@ module sharedMkHtml
         // used to make the HTML.
         return some( new pnodeEdits.Selection(root, thePath, anchor, focus) ) ;
     }
+
+    export function stringIsInfixOperator( str : string ) : boolean {
+        return str.match( /^([+/!@#$%&*_+=?;:`~&]|-|^|\\)+$/ ) !== null ;
+    }  
 }
 
 export = sharedMkHtml;

--- a/typescriptSrc/treeManager.ts
+++ b/typescriptSrc/treeManager.ts
@@ -58,7 +58,7 @@ module treeManager {
                     return this.makeNumberLiteralNode(selection);
                 case "trueliteral":
                     return this.makeTrueBooleanLiteralNode(selection);
-                case "falseiteral":
+                case "falseliteral":
                     return this.makeFalseBooleanLiteralNode(selection);
                 case "nullliteral":
                     return this.makeNullLiteralNode(selection);


### PR DESCRIPTION
Added palette items for call and null.
Added click handlers to palette items.
Factored out code to identify infix operators for "call world" nodes.  This subroutine should be used for both svg and html production.