### PR TITLE
Small fix for breaking tests.

### DIFF
--- a/typescriptSrc/test/world-test.ts
+++ b/typescriptSrc/test/world-test.ts
@@ -11,6 +11,7 @@ import assert = require( '../assert' ) ;
 import valueTypes = require( '../valueTypes' ) ;
 import vms = require( '../vms' ) ;
 import world = require('../world') ;
+import ObjectV = valueTypes.ObjectV;
 import Evaluation = vms.Evaluation;
 import VMS = vms.VMS;
 import World = world.World;


### PR DESCRIPTION
World-tests wasn't importing ObjectV, so when constructing a new World the transaction manager was being passed to super (i.e. StringV) as undefined.