### PR TITLE
Map Expr Seq to Stack Frame

### DIFF
--- a/typescriptSrc/interpreter.ts
+++ b/typescriptSrc/interpreter.ts
@@ -381,7 +381,7 @@ module interpreter {
             } // end for
             vms.getEval().pushOntoVarStack( stackFrame ) ;
             // Now map this node to say it's been previsited.
-            vms.putExtraInformation( 0 ) ;
+            vms.putExtraInformation( stackFrame ) ;
             vms.setReady( false ) ; }
         else {
             // Postvisit.

--- a/typescriptSrc/vms.ts
+++ b/typescriptSrc/vms.ts
@@ -368,15 +368,16 @@ module vms{
             return this.map.get( collections.snoc(p, childNum ) ) ; 
         }
 
-        public hasExtraInformation(  ) : boolean {
-            if( this.pending.get() === null ) return false ;
-            const p = this.pending.get() as List<number> ;
+        public hasExtraInformation( path ? : List<number> ) : boolean {
+            const p : List<number>| null = typeof(path)=="undefined" ? this.pending.get() : path ;
+            if( p === null ) return false ;
             return this.extraInformationMap.isMapped( p ) ; 
         }
 
-        public getExtraInformation( ) : {} {
-            assert.checkPrecondition( this.pending.get() !== null ) ;
-            const p = this.pending.get() as List<number> ;
+        public getExtraInformation( path ? : List<number> ) : {} {
+            const p : List<number>| null = typeof(path)=="undefined" ? this.pending.get() : path ;
+            if( p === null ) return assert.failedPrecondition() ;
+            assert.checkPrecondition( this.extraInformationMap.isMapped( p ) ) ;
             return this.extraInformationMap.get( p ) ; 
         }
 


### PR DESCRIPTION
Changed the behaviour of ExprSeqLabel.  When an ExprSeqLabel node is …previsited it creates a stack frame.  In the extra information map the (path of the) node is now mapped to that stack frame.  The reason is that this should make it easier for the animator to find the stack frame associated with a given node.  Also I added interface to the Evaluation class to make it easier to get the extra information associated with a path.