### PR TITLE
Created array literal label

### DIFF
--- a/typescriptSrc/animatorHelpers.ts
+++ b/typescriptSrc/animatorHelpers.ts
@@ -348,6 +348,47 @@ module animatorHelpers
                 makeFancyBorderSVG(parent, element, LIGHT_BLUE);
             }
             break ;
+            case labels.ArrayLiteralLabel.kindConst :
+            {
+                const childArray = element.children();
+
+                element.dmove(10, 10) ;
+                const padding : number = 15;
+                let y = 0;
+
+                const guardBox : svg.G = element.group() ;
+                // guardBox.addClass( "arrayGuardBox") ;
+                // guardBox.addClass( "H") ;
+                // guardBox.addClass( "workplace") ;
+                const textElement = guardBox.text("array").dmove(0, -5);
+                y += textElement.bbox().height + padding;
+                let len = findWidthOfLargestChild(childArray)+padding;
+                if(textElement.bbox().width + padding > len)
+                {
+                    len = textElement.bbox().width + padding;
+                }
+
+                doGuardBoxStylingAndBorderSVG(textElement, guardBox, LIGHT_BLUE, len, y);
+
+                y += padding;
+                let seqBoxY : number = 0;
+                const seqBox :  svg.G = element.group().dmove(10, y) ;
+                // doBox.addClass( "seqBox") ;
+                // doBox.addClass( "V") ;
+                // doBox.addClass( "workplace") ;
+                for (let i = 0; true; ++i) {
+                    if (i === childArray.length) break;
+                    seqBox.add(childArray[i].dmove(0, seqBoxY));
+                    seqBoxY += childArray[i].bbox().height + padding;
+                }
+                if(seqBoxY === 0) //i.e. there are no elements in this node
+                {
+                    seqBox.rect(10,10).opacity(0); //enforce a minimum size for ExprSeq-like nodes.
+                }
+
+                makeFancyBorderSVG(parent, element, LIGHT_BLUE);
+            }
+            break ;
             case labels.AccessorLabel.kindConst :
             {
                 const childArray = element.children();

--- a/typescriptSrc/createHtmlElements.ts
+++ b/typescriptSrc/createHtmlElements.ts
@@ -58,6 +58,7 @@ module createHtmlElements {
 		createTexted("div", "leftSideButton paletteItem", "nullliteral", palette, "\u23da");
 		createTexted("div", "leftSideButton paletteItem", "lambda", palette, "\u03BB");
 		createTexted("div", "leftSideButton paletteItem", "objectliteral", palette, "$");
+		createTexted("div", "leftSideButton paletteItem", "arrayliteral", palette, "array");
 		createTexted("div", "leftSideButton paletteItem", "accessor", palette, "[ ]");
 
 		//User-related elements. All added functionalities of the elements are in userRelated module.

--- a/typescriptSrc/labels.ts
+++ b/typescriptSrc/labels.ts
@@ -556,13 +556,51 @@ module labels {
             return { kind: ObjectLiteralLabel.kindConst, } ;
         }
 
-        public static fromJSON( json : object ) : WhileLabel {
+        public static fromJSON( json : object ) : ObjectLiteralLabel {
             return ObjectLiteralLabel.theObjectLiteralLabel ;
         }
             
         public kind() : string { return ObjectLiteralLabel.kindConst ; }
     }
     pnode.registry[ ObjectLiteralLabel.kindConst ] = ObjectLiteralLabel ;
+
+      /** Array Literal expressions */
+    export class ArrayLiteralLabel extends ExprLabel {
+    
+    public static readonly kindConst : string = "ArrayLiteralLabel" ;
+
+    public isValid(children:Array<PNode>) : boolean {
+        return children.every( (c:PNode) => 
+                c.isExprNode() ) ;
+    }
+
+    public toString():string {
+        return "array";
+    }
+
+    /*private*/
+    constructor() {
+        super();
+    }
+
+    // Singleton
+    public static readonly theArrayLiteralLabel = new ArrayLiteralLabel();
+    
+    public hasVerticalLayout() : boolean {return true;}
+    
+    public hasDropZonesAt(start : number): boolean { return true; }
+
+    public toJSON() : object {
+        return { kind: ArrayLiteralLabel.kindConst, } ;
+    }
+
+    public static fromJSON( json : object ) : ArrayLiteralLabel {
+        return ArrayLiteralLabel.theArrayLiteralLabel ;
+    }
+        
+    public kind() : string { return ArrayLiteralLabel.kindConst ; }
+    }
+    pnode.registry[ ArrayLiteralLabel.kindConst ] = ArrayLiteralLabel ;
 
     /** Assignments.  */
     export class AccessorLabel extends ExprLabel {

--- a/typescriptSrc/plaay-style.css
+++ b/typescriptSrc/plaay-style.css
@@ -591,6 +591,32 @@ div.objectBox {
     padding-left: 0px ;
 }
 
+div.arrayGuardBox:before { content: "array" ;
+    display: inline ;
+    vertical-align: top ;
+    color: rgb(135,206,250) ;
+    font-size: large ;
+    margin: 0px 5px 0px 0px ;
+}
+
+div.arrayGuardBox {
+    border-top: none ;
+    border-bottom: medium dashed rgb(135,206,250) ;
+    border-left: none ;
+    border-right: none ;
+    padding-left: 10px ;
+    -webkit-align-self: stretch ; align-self: stretch ;
+}
+
+div.arrayBox {
+    border-top: medium solid rgb(135,206,250) ;
+    border-bottom: medium solid rgb(135,206,250) ;
+    border-left: 10px solid rgb(135,206,250) ;
+    border-right: thin solid rgb(135,206,250) ;
+    border-radius: 10px ;
+    padding-left: 0px ;
+}
+
 div.accessor {
     border:thin solid rgb(190, 133, 197) ; /* Mauve */
     border-radius: 5px ;

--- a/typescriptSrc/sharedMkHtml.ts
+++ b/typescriptSrc/sharedMkHtml.ts
@@ -254,6 +254,36 @@ module sharedMkHtml
                 result.append( seqBox );
             }
             break ;
+            case labels.ArrayLiteralLabel.kindConst :
+            {
+                const guardBox : JQuery = $( document.createElement("div") ) ;
+                guardBox.addClass( "arrayGuardBox") ;
+                guardBox.addClass( "H") ;
+                guardBox.addClass( "workplace") ;
+
+                const seqBox : JQuery = $( document.createElement("div") ) ;
+                seqBox.addClass( "seqBox" ) ;
+                seqBox.addClass( "V" ) ;
+                seqBox.addClass( "workplace") ;
+                // Add children and drop zones.
+                for (let i = 0; true; ++i) {
+                    const dz = makeDropZone(i, true ) ;
+                    dropzones.push( dz ) ;
+                    seqBox.append(dz);
+                    if (i === children.length) break;
+                    seqBox.append(children[i]);
+                }
+
+                result  = $(document.createElement("div")) ;
+                result.addClass( "arrayBox" ) ;
+                result.addClass( "V" ) ;
+                result.addClass( "workplace" ) ;
+                result.addClass( "canDrag" ) ;
+                result.addClass( "droppable" ) ;
+                result.append( guardBox );
+                result.append( seqBox );
+            }
+            break ;
             case labels.AccessorLabel.kindConst :
             {
                 result = $(document.createElement("div")) ;

--- a/typescriptSrc/treeManager.ts
+++ b/typescriptSrc/treeManager.ts
@@ -64,6 +64,8 @@ module treeManager {
                     return this.makeNullLiteralNode(selection);
                 case "objectliteral":
                     return this.makeObjectLiteralNode(selection);
+                case "arrayliteral":
+                    return this.makeArrayLiteralNode(selection);
 
                 //variables & variable manipulation
                 case "var":
@@ -129,6 +131,14 @@ module treeManager {
         private makeObjectLiteralNode(selection:Selection) : Option<Selection> {
             const objectnode = pnode.make(labels.ObjectLiteralLabel.theObjectLiteralLabel, []);
             const template = new Selection( objectnode, list<number>(), 0, 0 ) ;
+            const edit = replaceOrEngulfTemplateEdit( template ) ;
+            return edit.applyEdit(selection);
+        }
+
+        //arrays
+        private makeArrayLiteralNode(selection:Selection) : Option<Selection> {
+            const arraynode = pnode.make(labels.ArrayLiteralLabel.theArrayLiteralLabel, []);
+            const template = new Selection( arraynode, list<number>(), 0, 0 ) ;
             const edit = replaceOrEngulfTemplateEdit( template ) ;
             return edit.applyEdit(selection);
         }


### PR DESCRIPTION
Created a literal label for arrays. Like with objects, I didn't do the interpreter side.

I figure that arrays and objects will work very similarly for the interpreter. My assumption is that, with objects, you need to explicitly declare fields and give them names for them to be accessible. However in arrays, I assume that the declaration is implicit, so every child of the array node will be in the final array. i.e. this:

![array_example](https://user-images.githubusercontent.com/28740369/37619440-7b51f810-2b9c-11e8-8407-8246e21b4394.PNG)

will become an ObjectV with three fields: 0 ::= "test1", 1 ::= "test2", and 2 ::= 10.

This is why I don't allow variable declarations to be children of the array literal. It doesn't make sense to allow them for the same reason that we can't declare a variable to be another variable declaration.
