### PR TITLE
Interpreter arrays

### DIFF
--- a/typescriptSrc/interpreter.ts
+++ b/typescriptSrc/interpreter.ts
@@ -408,12 +408,10 @@ module interpreter {
             const val = vms.getChildVal(i);
             const name : string = i+"";
             const type : Type = Type.NOTYPE ;
-            const field = new Field( name, val, type, false, false, manager ) ;
+            const field = new Field(name, val, type, false, true, manager);
             array.addField(field) ;
         }
-        vms.getEval().pushOntoVarStack(array) ;
         vms.finishStep(array);
-        vms.getEval().popFromVarStack(); 
     }
 
     function previsitNode(vms: VMS) {

--- a/typescriptSrc/interpreter.ts
+++ b/typescriptSrc/interpreter.ts
@@ -404,20 +404,16 @@ module interpreter {
         const array = new ObjectV( manager ) ;
         const node = vms.getPendingNode() ;
         const sz = node.count() ;
-        for( let i=0; i < sz ; ++i ) {
+        for(let i = 0; i < sz ; ++i) {
             const val = vms.getChildVal(i);
             const name : string = i+"";
             const type : Type = Type.NOTYPE ;
             const field = new Field( name, val, type, false, false, manager ) ;
-            array.addField( field ) ;
+            array.addField(field) ;
         }
-        const isArrayField = new Field("isArray", new StringV("true"), Type.NOTYPE, false, false, manager);
-        array.addField(isArrayField);
-        const lengthField = new Field("length", new StringV(sz+""), Type.NOTYPE, false, false, manager);
-        array.addField(lengthField);
         vms.getEval().pushOntoVarStack(array) ;
         vms.finishStep(array);
-        vms.getEval().popFromVarStack() ; 
+        vms.getEval().popFromVarStack(); 
     }
 
     function previsitNode(vms: VMS) {

--- a/typescriptSrc/test/test-interpreter.ts
+++ b/typescriptSrc/test/test-interpreter.ts
@@ -1026,7 +1026,7 @@ describe('ArrayLiteralLabel', function(): void {
       assert.check(!vm.hasError());
       const val = vm.getFinalValue();
       assert.check(val instanceof ObjectV);
-      assert.check((val as ObjectV).numFields() === 2);
+      assert.check((val as ObjectV).numFields() === 4);
       assert.check(((val as ObjectV).getField("0").getValue() as StringV).getVal() === "12345");
       assert.check(((val as ObjectV).getField("1").getValue() as StringV).getVal() === "67890");
   });

--- a/typescriptSrc/test/test-interpreter.ts
+++ b/typescriptSrc/test/test-interpreter.ts
@@ -1026,9 +1026,61 @@ describe('ArrayLiteralLabel', function(): void {
       assert.check(!vm.hasError());
       const val = vm.getFinalValue();
       assert.check(val instanceof ObjectV);
-      assert.check((val as ObjectV).numFields() === 4);
+      assert.check((val as ObjectV).numFields() === 2);
       assert.check(((val as ObjectV).getField("0").getValue() as StringV).getVal() === "12345");
       assert.check(((val as ObjectV).getField("1").getValue() as StringV).getVal() === "67890");
+  });
+});
+
+describe('len built in', function(): void {
+  it('should return a len of 2', function(): void {
+    const array = new PNode(new labels.ArrayLiteralLabel(), [mkNumberLiteral("23"), mkNumberLiteral("123127645")]);
+    const lenCall = new PNode(new labels.CallWorldLabel("len", false), [array]);
+    const root = mkExprSeq([array, lenCall]);
+    const vm = makeStdVMS(root);
+    while (vm.canAdvance()) {
+      vm.advance();
+    }
+    assert.check(!vm.hasError());
+    const val = vm.getFinalValue();
+    assert.check(val instanceof StringV);
+    assert.check((val as StringV).getVal() === "2");
+  });
+});
+
+describe('push built in', function(): void {
+  it('should return a StringV equaling 1000', function(): void {
+    const array = new PNode(new labels.ArrayLiteralLabel(), [mkNumberLiteral("23")]);
+    const arrayDecl = mkVarDecl(mkVar("a"), mkNoTypeNd(), array);
+    const pushCall = new PNode(new labels.CallWorldLabel("push", false), [mkVar("a"), mkNumberLiteral("1000")]);
+    const accessor = new PNode(labels.AccessorLabel.theAccessorLabel, [mkVar("a"), labels.mkStringLiteral("1")]);
+    const root = mkExprSeq([arrayDecl, pushCall, accessor]);
+    const vm = makeStdVMS(root);
+    while (vm.canAdvance()) {
+      vm.advance();
+    }
+    assert.check(!vm.hasError());
+    const val = vm.getFinalValue();
+    assert.check(val instanceof StringV);
+    assert.check((val as StringV).getVal() === "1000");
+  });
+});
+
+describe('pop built in', function(): void {
+  it('should return a len of 2', function(): void {
+    const array = new PNode(new labels.ArrayLiteralLabel(), [mkNumberLiteral("1"), mkNumberLiteral("2"), mkNumberLiteral("3")]);
+    const arrayDecl = mkVarDecl(mkVar("a"), mkNoTypeNd(), array);
+    const popCall = new PNode(new labels.CallWorldLabel("pop", false), [mkVar("a")]);
+    const lenCall = new PNode(new labels.CallWorldLabel("len", false), [mkVar("a")]);
+    const root = mkExprSeq([arrayDecl, popCall, lenCall]);
+    const vm = makeStdVMS(root);
+    while (vm.canAdvance()) {
+      vm.advance();
+    }
+    assert.check(!vm.hasError());
+    const val = vm.getFinalValue();
+    assert.check(val instanceof StringV);
+    assert.check((val as StringV).getVal() === "2");
   });
 });
 

--- a/typescriptSrc/test/test-interpreter.ts
+++ b/typescriptSrc/test/test-interpreter.ts
@@ -1002,6 +1002,24 @@ describe('AccessorLabel', function(): void {
     });
 });
 
+describe('ArrayLiteralLabel', function(): void {
+  it('should evaluate to an ObjectV with 2 fields', function(): void {
+      const el1 = mkNumberLiteral("12345");
+      const el2 = mkNumberLiteral("67890");
+      const root = new PNode(new labels.ArrayLiteralLabel(), [el1, el2]);
+      const vm = makeStdVMS(root);
+      while (vm.canAdvance()) {
+        vm.advance();
+      }
+      assert.check(!vm.hasError());
+      const val = vm.getFinalValue();
+      assert.check(val instanceof ObjectV);
+      assert.check((val as ObjectV).numFields() === 2);
+      assert.check(((val as ObjectV).getField("0").getValue() as StringV).getVal() === "12345");
+      assert.check(((val as ObjectV).getField("1").getValue() as StringV).getVal() === "67890");
+  });
+});
+
 describe( 'ExprSeqLabel', function () : void {
     it( 'should evaluate to a StringV equaling 3', function () : void {
         const rootLabel = new labels.ExprSeqLabel();

--- a/typescriptSrc/valueTypes.ts
+++ b/typescriptSrc/valueTypes.ts
@@ -162,6 +162,11 @@ module valueTypes {
             return assert.failedPrecondition( "ObjectV.getField called with bad argument.") ;
         }
 
+        public popField() {
+          assert.checkPrecondition(this.fields.size() > 0);
+          this.fields.pop();
+        }
+
         public isClosureV() : boolean {
             return false;
         }

--- a/typescriptSrc/world.ts
+++ b/typescriptSrc/world.ts
@@ -248,7 +248,7 @@ module world {
             this.addField(orf);
 
             function lenStep(vms: VMS, args: Array<Value>) : void  {
-              if (!(args.length === 1)) {
+              if (args.length !== 1) {
                 vms.reportError("len expects 1 argument, of type object.");
                 return;
               }
@@ -294,7 +294,7 @@ module world {
             }
             const obj = args[0];
             if (!(obj instanceof ObjectV)) {
-              vms.reportError("push argument should be an object value.");
+              vms.reportError("pop argument should be an object value.");
               return;
             }
             const len = obj.numFields();

--- a/typescriptSrc/world.ts
+++ b/typescriptSrc/world.ts
@@ -246,6 +246,69 @@ module world {
             var or = new BuiltInV(orstep);
             var orf = new Field("or", or, Type.BOOL, true, true, manager);
             this.addField(orf);
+
+            function lenStep(vms: VMS, args: Array<Value>) : void  {
+              if (!(args.length === 1)) {
+                vms.reportError("len expects 1 argument, of type object.");
+                return;
+              }
+              const obj = args[0];
+              if (!(obj instanceof ObjectV)) {
+                vms.reportError("len only works with object values.");
+                return;
+              }
+              const len = obj.numFields();
+              const val = new StringV(len+"");
+              vms.finishStep(val);
+            }
+
+            const len = new BuiltInV(lenStep);
+            const lenf = new Field("len", len, Type.NUMBER, true, true, manager);
+            this.addField(lenf);
+
+            function pushStep(vms: VMS, args: Array<Value>) {
+              if (args.length !== 2) {
+                vms.reportError("push expects 2 arguments, an object and a value to be pushed.");
+                return;
+              }
+              const obj = args[0];
+              if (!(obj instanceof ObjectV)) {
+                vms.reportError("First argument should be an object value.");
+                return;
+              }
+              const val = args[1];
+              console.log(obj.numFields()+"");
+              const field = new Field(obj.numFields()+"", val, Type.NOTYPE, false, false, manager);
+              obj.addField(field);
+              vms.finishStep(DoneV.theDoneValue);
+            }
+
+            const push = new BuiltInV(pushStep);
+            const pushf = new Field("push", push, Type.NOTYPE, true, true, manager);
+            this.addField(pushf);
+
+          function popStep(vms: VMS, args: Array<Value>) {
+            if (args.length !== 1) {
+              vms.reportError("pop expects 1 arguments of type object.");
+              return;
+            }
+            const obj = args[0];
+            if (!(obj instanceof ObjectV)) {
+              vms.reportError("push argument should be an object value.");
+              return;
+            }
+            const len = obj.numFields();
+            if (!obj.hasField((len-1)+"")) {
+              vms.reportError("Cannot perform pop on " + obj.toString());
+              return;
+            }
+            obj.popField();
+            vms.finishStep(DoneV.theDoneValue);
+          }
+
+          const pop = new BuiltInV(popStep);
+          const popf = new Field("pop", pop, Type.NOTYPE, false, false, manager);
+          this.addField(popf);
         }
     }
 


### PR DESCRIPTION
This is branched off my interpreter-objects branch, so make sure that is merged before this.

This contains steppers for arrays as well as the len, push and pop built ins.

Something I noticed when testing this in the editor - the len and pop built ins accept a single argument, but by default the call world node pops up two placeholders to put arguments. This means that you need to delete one of them to get it to work properly. This is not really a big deal, but it is slightly awkward so I figured I would mention this. Not sure if it worth doing anything about it at this point in time though.